### PR TITLE
Gracefully handle failed requests

### DIFF
--- a/vminpoly.coffee
+++ b/vminpoly.coffee
@@ -27,10 +27,14 @@ ajax = (url, onload) ->
       return
     unless xmlhttp.status is 200
       throw "Error!"
+    console.log "INFO: processing #{url}"
     onload xmlhttp.responseText
     return
-  xmlhttp.open "GET", url, true
-  xmlhttp.send()
+  try
+    xmlhttp.open "GET", url, true
+    xmlhttp.send()
+  catch e
+    console.log "ERROR: #{e.message} (#{e.type}) when accessing #{url}"
   return
 
 # get window dimensions, cross-browser compatible

--- a/vminpoly.js
+++ b/vminpoly.js
@@ -42,10 +42,15 @@
       if (xmlhttp.status !== 200) {
         throw "Error!";
       }
+      console.log("INFO: processing " + url);
       onload(xmlhttp.responseText);
     };
-    xmlhttp.open("GET", url, true);
-    xmlhttp.send();
+    try {
+      xmlhttp.open("GET", url, true);
+      xmlhttp.send();
+    } catch (e) {
+      console.log("ERROR: " + e.message + " (" + e.type + ") when accessing " + url);
+    }
   };
 
   getViewportSize = function() {


### PR DESCRIPTION
Catches and logs exceptions when attempts to get stylesheets are blocked by the browser (due to, for example, cross-domain protection)
