### PR TITLE
Add support for *-keyframes rules.

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -292,7 +292,11 @@ AtRule.registry = {
 	'document': 'rule',
 	'font-feature-values': 'declaration',
 	'viewport': '',
-	'region-style': 'rule'
+	'region-style': 'rule',
+	'-webkit-keyframes': 'rule',
+	'-moz-keyframes': 'rule',
+	'-o-keyframes': 'rule',
+	'-ms-keyframes': 'rule'
 };
 
 function StyleRule() {


### PR DESCRIPTION
vminpoly was giving me trouble with the various -keyframes rules because they weren't recognized. This seems to fix the problem.