### PR TITLE
Be flexible in case of a missing rule.

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -59,6 +59,9 @@ function parse(tokens) {
 	var pop = function() {
 		var oldrule = stack.pop();
 		rule = stack[stack.length - 1];
+		if (rule === undefined) {
+			return false;
+		}
 		rule.append(oldrule);
 		return true;
 	}


### PR DESCRIPTION
I've run into an issue with CSS * rules. vminpoly was running into an error with the token DELIM(*). I thought I'd make it more flexible with missing rules.